### PR TITLE
remove tabs no main.html e corrigindo typo no join-cluster

### DIFF
--- a/install_k8s/main.yml
+++ b/install_k8s/main.yml
@@ -8,16 +8,16 @@
   - name: 'instalando o python'
     raw: 'apt-get install -y python'
   roles:
-  - { role: install-k8s,	tags: ["install_k8s_role"]}
+  - { role: install-k8s, tags: ["install_k8s_role"]}
 
 - hosts: k8s-master
   become: yes
   user: ubuntu
   roles:
-  - { role: create-cluster,	tags: ["create_cluster_role"]}
+  - { role: create-cluster, tags: ["create_cluster_role"]}
 
 - hosts: k8s-workers
   become: yes
   user: ubuntu
   roles:
-  - { role: join-workers,	tags: ["join_workers_role"]}
+  - { role: join-workers, tags: ["join_workers_role"]}

--- a/install_k8s/roles/join-workers/tasks/join-cluster.yml
+++ b/install_k8s/roles/join-workers/tasks/join-cluster.yml
@@ -9,7 +9,7 @@
 - name: "Kubeadm reset node cluster config"
   command: 
     kubeadm reset --force
-  register: kubeadm-reset_node
+  register: kubeadm_reset_node
 
 - name: "Kubeadm join"
   shell: 


### PR DESCRIPTION
primeiramente recebi erro por conta dos **\t** no arquivo **main.yaml** no root do projeto.
depois descobri que os nomes de variáveis dos _registers_ não aceitam hífen, então ajustei no **join-cluster.yaml**.
P.S.: Meus workers não estão conseguindo fazer o _join_. mas isso é para amanhã.
